### PR TITLE
[EGGO-27] Implement directory structure from spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,21 @@ export SPARK_MASTER_URL=local
 export STREAMING_JAR=$HADOOP_HOME/share/hadoop/tools/lib/hadoop-streaming-2.5.1.jar
 ```
 
-Generate the test dataset with
+Generate a test dataset with
 
 ```bash
 bin/toaster.py --local-scheduler VCF2ADAMTask --config test/registry/test-genotypes.json
 ```
 
-You can delete the test dataset with
+or
+
+```bash
+bin/toaster.py --local-scheduler BAM2ADAMTask --config test/registry/test-alignments.json
+```
+
+You can delete the test datasets with
 
 ```bash
 bin/toaster.py --local-scheduler DeleteDatasetTask --config test/registry/test-genotypes.json
+bin/toaster.py --local-scheduler DeleteDatasetTask --config test/registry/test-alignments.json
 ```

--- a/test/registry/test-alignments.json
+++ b/test/registry/test-alignments.json
@@ -1,0 +1,9 @@
+{
+    "name": "test-alignments",
+    "title": "Test SAM data",
+    "dag": "BAM2ADAMTask",
+    "editions": ["basic", "flat"],
+    "sources": [
+        {"format": "sam", "compression": false, "url": "https://raw.githubusercontent.com/bigdatagenomics/adam/master/adam-core/src/test/resources/reads12.sam"}
+    ]
+}

--- a/test/registry/test-genotypes.json
+++ b/test/registry/test-genotypes.json
@@ -3,6 +3,7 @@
     "title": "Test 1000 Genomes Project VCF data",
     "target": "test/genotypes",
     "dag": "VCF2ADAMTask",
+    "editions": ["basic", "flat"],
     "sources": [
         {"format": "vcf", "compression": true, "url": "https://github.com/bigdatagenomics/eggo/raw/master/test/resources/chr22.small.vcf.gz"}
     ]


### PR DESCRIPTION
This builds on https://github.com/bigdatagenomics/eggo/pull/22 to implement https://github.com/bigdatagenomics/eggo/issues/27. Basic and Flat editions have been implemented for both VCF and BAM.

Note that the BAM/SAM support relies on https://github.com/bigdatagenomics/adam/pull/650, but I think it may not have been working properly in Eggo before.
