### PR TITLE
[EGGO-48] Run eggo on a Cloudera Director provisioned cluster.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ eggo provision
 eggo deploy_config
 eggo setup_master
 eggo setup_slaves
+eggo delete_all:config=$EGGO_HOME/test/registry/test-genotypes.json
 eggo toast:config=$EGGO_HOME/test/registry/test-genotypes.json
 eggo teardown
 ```

--- a/conf/eggo/eggo-director.cfg
+++ b/conf/eggo/eggo-director.cfg
@@ -1,5 +1,9 @@
 ; Eggo "global" config
 
+; If new sections are added, ensure that
+; eggo.config.assert_eggo_config_complete is updated as well
+
+
 [dfs]
 ; The location of the result data sets in the targeted distributed file system
 ; (dfs). Currently supports S3 (s3n://), HDFS (hdfs://), and local (file://)
@@ -22,12 +26,13 @@ dfs_tmp_data_url: %(dfs_root_url)s/tmp
 context: director
 
 ; Random identifier that is generated on module load.  Do not set this manually
-;random_id: <generated-on-load>
+; as it's generated-on-load
+random_id:
 
 
 [versions]
-eggo_fork: bigdatagenomics
-eggo_branch: master
+eggo_fork: tomwhite
+eggo_branch: EGGO-48-director-wip
 
 adam_fork: bigdatagenomics
 adam_branch: master
@@ -63,7 +68,7 @@ streaming_jar: /opt/cloudera/parcels/CDH-5.3.3-1.cdh5.3.3.p0.5/lib/hadoop-mapred
 
 ; string compatible with the --master option to spark-submitthis string must
 ; evaluate correctly in a shell environment
-spark_master: yarn-cluster
+spark_master: yarn-client
 ; spark_master: local[2]
 
 ; path on worker machines where adam is built/installed
@@ -74,11 +79,16 @@ eggo_home: %(work_path)s/eggo
 
 
 [aws]
-; These can be set/overridden by setting corresponding local env vars (in ALL_CAPS)
-;aws_access_key_id: <MY_ACCESS_KEY>
-;aws_secret_access_key: <MY_SECRET_KEY>
-;ec2_key_pair: <MY_KEY>
-;ec2_private_key_file: <MY_KEY_FILE>
+; These can be set/overridden by setting corresponding local env vars (in
+; ALL_CAPS)
+
+; set these if using S3 as the underlying DFS
+aws_access_key_id:
+aws_secret_access_key:
+
+; set these if using EC2 for the execution context
+ec2_key_pair:
+ec2_private_key_file:
 
 
 [spark_ec2]
@@ -102,7 +112,7 @@ availability_zone:
 launcher_instance_type: m3.medium
 launcher_ami: ami-00a11e68  ; RHEL-6.5_GA_HVM-20140929-x86_64-11-Hourly2-GP2
 cluster_ami: %(launcher_ami)s
-num_workers: 2
+num_workers: 3
 stack_name: bdg-eggo
 user: ec2-user
 ; the pointers to the director configs are executed relative to CWD (which may

--- a/conf/eggo/eggo.cfg
+++ b/conf/eggo/eggo.cfg
@@ -109,9 +109,10 @@ stack_name: bdg-eggo
 region: us-east-1
 ; set this to a valid value to specify an availability zone:
 availability_zone:
-launcher_instance_type: m3.large
-launcher_ami: ami-a25415cb  ; RHEL 6.4 x86
+launcher_instance_type: m3.medium
+launcher_ami: ami-00a11e68  ; RHEL-6.5_GA_HVM-20140929-x86_64-11-Hourly2-GP2
 cluster_ami: %(launcher_ami)s
+num_workers: 3
 stack_name: bdg-eggo
 user: ec2-user
 ; the pointers to the director configs are executed relative to CWD (which may

--- a/eggo/dag.py
+++ b/eggo/dag.py
@@ -136,11 +136,10 @@ def _dnload_to_local_upload_to_dfs(source, destination, compression):
     # source: (string) URL suitable for curl
     # destination: (string) full Hadoop path of destination file name
     # compression: (bool) whether file needs to be decompressed
+    tmp_local_dir = mkdtemp(
+        prefix='tmp_eggo_',
+        dir=eggo_config.get('worker_env', 'work_path'))
     try:
-        tmp_local_dir = mkdtemp(
-            prefix='tmp_eggo_',
-            dir=eggo_config.get('worker_env', 'work_path'))
-        
         # 1. dnload file
         dnload_cmd = 'pushd {tmp_local_dir} && curl -L -O {source} && popd'
         p = Popen(dnload_cmd.format(tmp_local_dir=tmp_local_dir,
@@ -258,6 +257,7 @@ class PrepareHadoopDownloadTask(Task):
 
             # 3. Copy command file to Hadoop filesystem
             hdfs_client = HdfsClient()
+            hdfs_client.mkdir(os.path.dirname(self.hdfs_path), True)
             hdfs_client.put(tmp_command_file, self.hdfs_path)
         except:
             raise

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     scripts=['bin/eggo', 'bin/toaster.py'],
-    install_requires=['fabric', 'luigi', 'boto'],
+    #install_requires=['fabric', 'luigi', 'boto'], # fails when using Cloudera Director, http://stackoverflow.com/questions/28443041/python-daemon-2-0-5-wont-install-with-pip
     keywords=('bdg adam spark eggo genomics omics public data'),
     license='Apache License, Version 2.0',
     classifiers=[


### PR DESCRIPTION
With these changes I was able to toast a dataset on a Cloudera Director cluster. Some of the changes conflict with running using the Spark EC2 scripts, so we should figure out if they can easily be made to coexist, or if we remove support for them.
- ADAM is no longer compiled on the cluster. This is because there were Java 6/7 issues (both are installed and it was picking up the wrong one for part of the build). I think this is OK as long as we make it easier to supply an arbitrary ADAM tarball.
- The memory used by ADAM had to be reduced to fit in the 4GB limit on the cluster. I chose 3GB, but we could go a bit higher.
- I hit SPARK-4705 so had to turn off event logging.
- Ideally we would not have to install anything on the worker nodes, but there's still a need for Python's ordereddict (since the cluster uses Python 2.6). We could remove that need by going back to the shell script for the streaming job.
- Fabric wouldn't install on the cluster, but that's OK as it doesn't need to be installed (only needed on the client).
- Installing eggo with Luigi as a required dependency causes us to hit http://stackoverflow.com/questions/28443041/python-daemon-2-0-5-wont-install-with-pip. If the dependency is removed then it works. Not sure the best way to handle this.
