### PR TITLE
Don't hardcode Luigi v1.1.2

### DIFF
--- a/eggo/fabric_cli.py
+++ b/eggo/fabric_cli.py
@@ -188,7 +188,7 @@ def install_fabric_luigi():
     sudo('pip install mechanize')
     sudo('pip install fabric')
     sudo('pip install ordereddict')  # for py2.6 compat (for luigi)
-    sudo('pip install luigi==1.1.2')
+    sudo('pip install luigi')
 
 
 def install_adam(work_path, adam_home, maven_version, fork, branch):
@@ -291,7 +291,7 @@ def setup_slaves():
         install_pypa()
         if exec_ctx == 'director':
             install_git()
-        sudo('pip install ordereddict')  # for py2.6 compat (for luigi)
+        install_fabric_luigi()
         install_eggo(work_path, eggo_home, eggo_fork, eggo_branch)
 
     if exec_ctx in ['director', 'spark_ec2']:

--- a/test/jenkins/run-spark_ec2.sh
+++ b/test/jenkins/run-spark_ec2.sh
@@ -34,7 +34,7 @@ virtualenv eggo_venv && source eggo_venv/bin/activate
 pip install -U pip  # python-daemon only installs with a newer version of pip
 pip install -U setuptools  # http://www.fabfile.org/faq.html#fabric-installs-but-doesn-t-run
 pip install pytest
-pip install fabric luigi==1.1.2 boto # depended on by eggo
+pip install fabric luigi boto # depended on by eggo
 pip install .  # install eggo
 
 


### PR DESCRIPTION
The new release of Luigi added a dependency on `cached_property`, which wasn't being found on the slave nodes.  This change installs Luigi on the slave nodes too, including all of Luigi's dependencies.
