### PR TITLE
Generalize AdamBasicTask for any ADAM command. Closes #13

### DIFF
--- a/conf/eggo/eggo-director.cfg
+++ b/conf/eggo/eggo-director.cfg
@@ -77,6 +77,9 @@ adam_home: %(work_path)s/adam
 ; path on worker machines where the eggo repo is checked out
 eggo_home: %(work_path)s/eggo
 
+; memory allocated to spark on each slave. This is a configuration parameter for spark-submit
+executor_memory: 55G
+
 
 [aws]
 ; These can be set/overridden by setting corresponding local env vars (in

--- a/conf/eggo/eggo.cfg
+++ b/conf/eggo/eggo.cfg
@@ -79,6 +79,9 @@ adam_home: %(work_path)s/adam
 ; last component of the path must be 'eggo'
 eggo_home: %(work_path)s/eggo
 
+; memory allocated to spark on each slave. This is a configuration parameter for spark-submit
+executor_memory: 55G
+
 
 [aws]
 ; These can be set/overridden by setting corresponding local env vars (in

--- a/examples/batch_transform.py
+++ b/examples/batch_transform.py
@@ -1,0 +1,73 @@
+# Licensed to Big Data Genomics (BDG) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The BDG licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Luigi workflow to convert a batch of bams to ADAM"""
+import os.path
+
+import luigi
+from luigi import Parameter, WrapperTask
+from luigi.s3 import S3PathTask, S3Target, S3Client
+
+from eggo.dag import ADAMBasicTask
+
+
+def convert_s3n(s):
+    return s.replace('s3://', 's3n://')
+
+
+class ADAMTransformTask(ADAMBasicTask):
+
+    source_uri = Parameter()
+    destination_uri = Parameter(None)
+
+    @property
+    def adam_command(self):
+        return 'transform {source} {target}'.format(
+            source=self.input().path,
+            target=self.output().path)
+
+    def requires(self):
+        return S3PathTask(path=self.source_uri)
+
+    def output(self):
+        if self.destination_uri is not None:
+            return S3Target(self.destination_uri)
+        return S3Target(self.source_uri.replace('.bam', '.adam'))
+
+
+class BatchTransform(WrapperTask):
+
+    source_folder = Parameter()
+    destination_folder = Parameter(None)
+
+    def requires(self):
+        source_folder_s3n = convert_s3n(self.source_folder)
+
+        if self.destination_folder is not None:
+            destination_folder_s3n = convert_s3n(self.destination_folder)
+        else:
+            destination_folder_s3n = source_folder_s3n
+
+        s3 = S3Client()
+        for key_path in s3.list(self.source_folder):
+            if key_path.endswith('.bam') or key_path.endswith('.sam'):
+                source_uri = os.path.join(source_folder_s3n, key_path)
+                destination_uri = os.path.join(destination_folder_s3n, key_path.replace('.bam', '.adam'))
+                yield ADAMTransformTask(source_uri=source_uri, destination_uri=destination_uri)
+
+
+if __name__ == '__main__':
+    luigi.run()

--- a/examples/count_kmers.py
+++ b/examples/count_kmers.py
@@ -1,0 +1,63 @@
+# Licensed to Big Data Genomics (BDG) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The BDG licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Luigi workflow to convert bams to ADAM and count kmers"""
+
+import luigi
+from luigi import Parameter
+from luigi.s3 import S3Target, S3PathTask
+
+from eggo.dag import ADAMBasicTask
+
+
+class ADAMTransformTask(ADAMBasicTask):
+
+    source_uri = Parameter()
+
+    @property
+    def adam_command(self):
+        return 'transform {source} {target}'.format(
+            source=self.input().path,
+            target=self.output().path)
+
+    def requires(self):
+        return S3PathTask(path=self.source_uri)
+
+    def output(self):
+        return S3Target(self.source_uri.replace('.bam', '.adam'))
+
+
+class CountKmersTask(ADAMBasicTask):
+
+    source_uri = Parameter()
+    kmer_length = Parameter(21)
+
+    @property
+    def adam_command(self):
+        return 'count_kmers {source} {target} {kmer_length}'.format(
+            source=self.input().path,
+            target=self.output().path,
+            kmer_length=self.kmer_length)
+
+    def requires(self):
+        return ADAMTransformTask(source_uri=self.source_uri)
+
+    def output(self):
+        return S3Target(self.source_uri.replace('.bam', '.kmer'))
+
+
+if __name__ == '__main__':
+    luigi.run()

--- a/test/jenkins/conf/eggo.jenkins.local.cfg
+++ b/test/jenkins/conf/eggo.jenkins.local.cfg
@@ -71,6 +71,9 @@ adam_home: %(work_path)s/adam
 ; path on worker machines where the eggo repo is checked out
 eggo_home: %(work_path)s/eggo
 
+; memory allocated to spark on each slave. This is a configuration parameter for spark-submit
+executor_memory: 55G
+
 
 [aws]
 ; These can be set/overridden by setting corresponding local env vars (in ALL_CAPS)

--- a/test/jenkins/conf/eggo.jenkins.spark_ec2.cfg
+++ b/test/jenkins/conf/eggo.jenkins.spark_ec2.cfg
@@ -72,6 +72,9 @@ adam_home: %(work_path)s/adam
 ; path on worker machines where the eggo repo is checked out
 eggo_home: %(work_path)s/eggo
 
+; memory allocated to spark on each slave. This is a configuration parameter for spark-submit
+executor_memory: 55G
+
 
 [aws]
 ; These can be set/overridden by setting corresponding local env vars (in ALL_CAPS)


### PR DESCRIPTION
Hey Uri, 

Let me know if this is along the lines you were thinking with #13. This works on spark-ec2 (Spark 1.3/Hadoop 2.6) for the included example workflows and for toaster.py with `test/test-genotypes.json`, but I'm still debugging some strange behavior for `test-alignments.json`.  

I can also expose `executor-memory` in a separate PR if you only want that piece of the code.

Changes:
- Factor out reusable ADAM CLI task class
- Add example workflows using ADAMBasicTask base class
- Expose `executor-memory` flag to spark-submit
